### PR TITLE
00000000-template: Add a template for design docs

### DIFF
--- a/00000000-template.md
+++ b/00000000-template.md
@@ -1,0 +1,49 @@
+tags: []
+---
+
+# Title
+
+## Essentials
+
+### Header
+
+Date: <must match the prefixed date of the filename>
+
+Owner:
+
+Accountable:
+-
+
+Consulted:
+-
+
+Informed:
+-
+
+### Context
+
+### Goals
+
+### Approach / Design
+
+## Disclaimers
+
+### Anti-goals
+
+### Alternatives considered
+
+### Open question
+
+## Reminders
+
+### Security / Privacy
+
+### Observability
+
+### Test plan
+
+### Rollout
+
+### Rollback
+
+## Out of scope

--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ Workspace for all Storj design documents
 
   The additional files must be store in a directory located in the root of this repository with the
   same name of the document without the `.md` extension.
+- The documents must use the last version of the template document
+- [00000000-template.md](00000000-template.md]). The matches the structure that we outlined in our
+  Clonfluence page
+  [proposal design document process](https://storjlabs.atlassian.net/wiki/spaces/delivery/pages/2548137985/Design+Doc+Process+Proposal+2023)
+  (non-public document).


### PR DESCRIPTION
Add a template document to have a starting point for new design documents to keep them with a similar structure and sections.

Inform about it in the README.

Closes #5 