### PR TITLE
Remove hijacked repo reference from API renovation doc

### DIFF
--- a/20211112-api-renovation.md
+++ b/20211112-api-renovation.md
@@ -58,7 +58,7 @@ Feature list:
 
 ## Rationale
 
-We [experimented a little](https://github.com/xaresys/storj-api-gen) with writing our own custom code generator. The process was straightforward and gave us an idea of how to proceed with API generation. Although there are pre-existing API code generators, we will build a custom one for the sake of flexibility and ease of maintenance.
+We experimented a little with writing our own custom code generator. The process was straightforward and gave us an idea of how to proceed with API generation. Although there are pre-existing API code generators, we will build a custom one for the sake of flexibility and ease of maintenance.
 
 ## Implementation
 


### PR DESCRIPTION
One of our repositories referenced in this design doc was hosted under an employee's username. The username was later abandoned and subsequently claimed by an unrelated individual, who now controls a repository with the same name. The link in this doc currently resolves to that repository and not ours, so it has been removed.